### PR TITLE
Set correct partition for efibootmgr

### DIFF
--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -101,9 +101,9 @@ case "$1" in
     add-efi)
         entry="$EFI/$NAME.efi"
         [ -f "$ESP/$entry" ] || error "Error: EFI images are not generated yet."
-        MOUNT="$(findmnt -n -o SOURCE -T "$ESP")"
-        PART=${MOUNT##*[!0-9]}
-        efibootmgr -d $MOUNT -p $PART -c -l "${entry//\//\\}" -L "$NAME"
+        mount="$(findmnt -n -o SOURCE -T "$ESP")"
+        partition="${mount##*[!0-9]}"
+        efibootmgr -d "$mount" -p "$partition" -c -l "${entry//\//\\}" -L "$NAME"
         ;;
 
     enroll-keys)

--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -101,7 +101,9 @@ case "$1" in
     add-efi)
         entry="$EFI/$NAME.efi"
         [ -f "$ESP/$entry" ] || error "Error: EFI images are not generated yet."
-        efibootmgr -d "$(findmnt -n -o SOURCE -T "$ESP")" -c -l "${entry//\//\\}" -L "$NAME"
+        MOUNT="$(findmnt -n -o SOURCE -T "$ESP")"
+        PART=${MOUNT##*[!0-9]}
+        efibootmgr -d $MOUNT -p $PART -c -l "${entry//\//\\}" -L "$NAME"
         ;;
 
     enroll-keys)


### PR DESCRIPTION
Hello,

I just tried out arch-secure-boot since it seems like a lightweight alternative to grub - very nice idea!
After a reboot the boot entry vanished.
At the moment `add-efi` does not really work because efibootmgr sets the partition to 1 even if you pass it with `-d`. So I used bash expansion to extract the partition number and for my use cases it works quite well now but I am not quite sure this covers every edge case.