### PR TITLE
Improve entry names for lts and efi-shell

### DIFF
--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -12,7 +12,8 @@ mkdir -p "$DIR" "$KEYSDIR" "$SBKEYSDIR"
 ESP="${ESP:-/efi}"
 EFI="${EFI:-/EFI/arch}"
 KERNEL="${KERNEL:-linux}"
-NAME="${NAME:-secure-boot-$KERNEL}"
+PREFIX="${PREFIX:-secure-boot}"
+NAME="${NAME:-$PREFIX-$KERNEL}"
 SUBVOLUME_ROOT="${SUBVOLUME_ROOT:-root}"
 SUBVOLUME_SNAPSHOT="${SUBVOLUME_SNAPSHOT:-snapshots/%1/snapshot}" # %1 is replaced with snapshot ID
 
@@ -30,6 +31,7 @@ $cmd
 ESP=$ESP
 EFI=$EFI
 KERNEL=$KERNEL
+PREFIX=$PREFIX
 NAME=$NAME
 CMDLINE=$CMDLINE
 EOF
@@ -67,7 +69,7 @@ case "$1" in
         sed -i "s|subvol=$SUBVOLUME_ROOT|subvol=$SUBVOLUME_SNAPSHOT|g" recovery.nsh
 
         cat /boot/*-ucode.img "/boot/initramfs-$KERNEL.img" > ucode-initramfs.img
-        cp /usr/share/edk2-shell/x64/Shell_Full.efi "$NAME-efi-shell-unsigned.efi"
+        cp /usr/share/edk2-shell/x64/Shell_Full.efi "$PREFIX-efi-shell-unsigned.efi"
 
         objcopy \
             --add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
@@ -86,18 +88,18 @@ case "$1" in
             --add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
             --add-section .linux=/boot/vmlinuz-linux-lts --change-section-vma .linux=0x40000 \
             --add-section .initrd=/boot/initramfs-linux-lts-fallback.img --change-section-vma .initrd=0x3000000 \
-            /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$NAME-recovery-lts-unsigned.efi"
+            /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$PREFIX-linux-recovery-lts-unsigned.efi"
 
-        for flavor in '' '-recovery' '-recovery-lts' '-efi-shell'; do
-            sbsign --key "$KEYSDIR/db.key" --cert "$KEYSDIR/db.crt" --output "${NAME}${flavor}.efi" "${NAME}${flavor}-unsigned.efi"
+        for image in "$NAME" "$NAME-recovery" "$PREFIX-linux-recovery-lts" "$PREFIX-efi-shell"; do
+            sbsign --key "$KEYSDIR/db.key" --cert "$KEYSDIR/db.crt" --output "$image.efi" "$image-unsigned.efi"
         done
 
         sbsign --key "$KEYSDIR/db.key" --cert "$KEYSDIR/db.crt" /usr/lib/fwupd/efi/fwupdx64.efi
 
         mkdir -p "$ESP/$EFI"
         cp recovery.nsh "$ESP"
-        for flavor in '' '-recovery' '-recovery-lts' '-efi-shell'; do
-            cp "${NAME}${flavor}.efi" "$ESP/$EFI"
+        for image in "$NAME" "$NAME-recovery" "$PREFIX-linux-recovery-lts" "$PREFIX-efi-shell"; do
+            cp "$image.efi" "$ESP/$EFI"
         done
         ;;
 

--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -12,8 +12,11 @@ mkdir -p "$DIR" "$KEYSDIR" "$SBKEYSDIR"
 ESP="${ESP:-/efi}"
 EFI="${EFI:-/EFI/arch}"
 KERNEL="${KERNEL:-linux}"
-PREFIX="${PREFIX:-secure-boot}"
-NAME="${NAME:-$PREFIX-$KERNEL}"
+KERNEL_LTS="linux-lts"
+NAME_PREFIX="secure-boot"
+NAME="$NAME_PREFIX-$KERNEL"
+NAME_LTS="$NAME_PREFIX-$KERNEL_LTS"
+NAME_EFI_SHELL="$NAME_PREFIX-efi-shell"
 SUBVOLUME_ROOT="${SUBVOLUME_ROOT:-root}"
 SUBVOLUME_SNAPSHOT="${SUBVOLUME_SNAPSHOT:-snapshots/%1/snapshot}" # %1 is replaced with snapshot ID
 
@@ -31,8 +34,6 @@ $cmd
 ESP=$ESP
 EFI=$EFI
 KERNEL=$KERNEL
-PREFIX=$PREFIX
-NAME=$NAME
 CMDLINE=$CMDLINE
 EOF
 }
@@ -69,7 +70,7 @@ case "$1" in
         sed -i "s|subvol=$SUBVOLUME_ROOT|subvol=$SUBVOLUME_SNAPSHOT|g" recovery.nsh
 
         cat /boot/*-ucode.img "/boot/initramfs-$KERNEL.img" > ucode-initramfs.img
-        cp /usr/share/edk2-shell/x64/Shell_Full.efi "$PREFIX-efi-shell-unsigned.efi"
+        cp /usr/share/edk2-shell/x64/Shell_Full.efi "$NAME_EFI_SHELL-unsigned.efi"
 
         objcopy \
             --add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
@@ -86,11 +87,11 @@ case "$1" in
 
         objcopy \
             --add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
-            --add-section .linux=/boot/vmlinuz-linux-lts --change-section-vma .linux=0x40000 \
-            --add-section .initrd=/boot/initramfs-linux-lts-fallback.img --change-section-vma .initrd=0x3000000 \
-            /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$PREFIX-linux-lts-recovery-unsigned.efi"
+            --add-section .linux="/boot/vmlinuz-$KERNEL_LTS" --change-section-vma .linux=0x40000 \
+            --add-section .initrd="/boot/initramfs-$KERNEL_LTS-fallback.img" --change-section-vma .initrd=0x3000000 \
+            /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$NAME_LTS-recovery-unsigned.efi"
 
-        for image in "$NAME" "$NAME-recovery" "$PREFIX-linux-lts-recovery" "$PREFIX-efi-shell"; do
+        for image in "$NAME" "$NAME-recovery" "$NAME_LTS-recovery" "$NAME_EFI_SHELL"; do
             sbsign --key "$KEYSDIR/db.key" --cert "$KEYSDIR/db.crt" --output "$image.efi" "$image-unsigned.efi"
         done
 
@@ -98,7 +99,7 @@ case "$1" in
 
         mkdir -p "$ESP/$EFI"
         cp recovery.nsh "$ESP"
-        for image in "$NAME" "$NAME-recovery" "$PREFIX-linux-lts-recovery" "$PREFIX-efi-shell"; do
+        for image in "$NAME" "$NAME-recovery" "$NAME_LTS-recovery" "$NAME_EFI_SHELL"; do
             cp "$image.efi" "$ESP/$EFI"
         done
         ;;

--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -98,9 +98,14 @@ case "$1" in
         sbsign --key "$KEYSDIR/db.key" --cert "$KEYSDIR/db.crt" /usr/lib/fwupd/efi/fwupdx64.efi
 
         mkdir -p "$ESP/$EFI"
-        cp recovery.nsh "$ESP"
+
+        echo "Removing older EFI images..."
+        find "$ESP/$EFI" -mindepth 1 -maxdepth 1 -name "$NAME_PREFIX-*.efi" -print -exec rm '{}' +
+
+        echo "Copying new EFI images..."
+        cp -v recovery.nsh "$ESP"
         for image in "$NAME" "$NAME-recovery" "$NAME_LTS-recovery" "$NAME_EFI_SHELL"; do
-            cp "$image.efi" "$ESP/$EFI"
+            cp -v "$image.efi" "$ESP/$EFI"
         done
         ;;
 

--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -88,9 +88,9 @@ case "$1" in
             --add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
             --add-section .linux=/boot/vmlinuz-linux-lts --change-section-vma .linux=0x40000 \
             --add-section .initrd=/boot/initramfs-linux-lts-fallback.img --change-section-vma .initrd=0x3000000 \
-            /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$PREFIX-linux-recovery-lts-unsigned.efi"
+            /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$PREFIX-linux-lts-recovery-unsigned.efi"
 
-        for image in "$NAME" "$NAME-recovery" "$PREFIX-linux-recovery-lts" "$PREFIX-efi-shell"; do
+        for image in "$NAME" "$NAME-recovery" "$PREFIX-linux-lts-recovery" "$PREFIX-efi-shell"; do
             sbsign --key "$KEYSDIR/db.key" --cert "$KEYSDIR/db.crt" --output "$image.efi" "$image-unsigned.efi"
         done
 
@@ -98,7 +98,7 @@ case "$1" in
 
         mkdir -p "$ESP/$EFI"
         cp recovery.nsh "$ESP"
-        for image in "$NAME" "$NAME-recovery" "$PREFIX-linux-recovery-lts" "$PREFIX-efi-shell"; do
+        for image in "$NAME" "$NAME-recovery" "$PREFIX-linux-lts-recovery" "$PREFIX-efi-shell"; do
             cp "$image.efi" "$ESP/$EFI"
         done
         ;;


### PR DESCRIPTION
Those should not include kernel name as they are not based on it.

Fixes #10 