### PR TITLE
Improve pacman hook

### DIFF
--- a/pacman-hooks/95-arch-secure-boot-generate-efi.hook
+++ b/pacman-hooks/95-arch-secure-boot-generate-efi.hook
@@ -5,6 +5,7 @@ Type = Path
 Target = usr/lib/modules/*/vmlinuz
 Target = usr/lib/initcpio/*
 Target = boot/*-ucode.img
+Target = usr/share/edk2-shell/x64/Shell_Full.efi
 
 [Action]
 Description = Generating signed EFI boot files

--- a/pacman-hooks/95-arch-secure-boot-generate-efi.hook
+++ b/pacman-hooks/95-arch-secure-boot-generate-efi.hook
@@ -1,7 +1,7 @@
 [Trigger]
 Operation = Install
 Operation = Upgrade
-Type = File
+Type = Path
 Target = usr/lib/modules/*/vmlinuz
 Target = usr/lib/initcpio/*
 Target = boot/*-ucode.img


### PR DESCRIPTION
From [man alpm-hooks](https://man.archlinux.org/man/alpm-hooks.5.en) :

> File is a deprecated alias for Path and will be removed in a future release.