### PR TITLE
generate-efi: compute section offsets dynamically

### DIFF
--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -72,23 +72,31 @@ case "$1" in
         cat /boot/*-ucode.img "/boot/initramfs-$KERNEL.img" > ucode-initramfs.img
         cp /usr/share/edk2-shell/x64/Shell_Full.efi "$NAME_EFI_SHELL-unsigned.efi"
 
+        osrel_offset="$(objdump -h /usr/lib/systemd/boot/efi/linuxx64.efi.stub | awk 'NF==7 {size=strtonum("0x"$3); offset=strtonum("0x"$4)} END {print size + offset}')"
+        kernel_offset="$((osrel_offset + $(stat -Lc%s /etc/os-release)))"
+
+        initrd_offset_from_default_kernel="$((kernel_offset + $(stat -Lc%s "/boot/vmlinuz-$KERNEL")))"
+        initrd_offset_from_lts_kernel="$((kernel_offset + $(stat -Lc%s "/boot/vmlinuz-$KERNEL_LTS")))"
+
+        cmdline_offset="$((initrd_offset_from_default_kernel + $(stat -Lc%s ucode-initramfs.img)))"
+
         objcopy \
-            --add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
-            --add-section .cmdline=cmdline --change-section-vma .cmdline=0x30000 \
-            --add-section .linux="/boot/vmlinuz-$KERNEL" --change-section-vma .linux=0x40000 \
-            --add-section .initrd=ucode-initramfs.img --change-section-vma .initrd=0x3000000 \
+            --add-section .osrel=/etc/os-release --change-section-vma .osrel="$(printf 0x%x "$osrel_offset")" \
+            --add-section .linux="/boot/vmlinuz-$KERNEL" --change-section-vma .linux="$(printf 0x%x "$kernel_offset")" \
+            --add-section .initrd=ucode-initramfs.img --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_default_kernel")" \
+            --add-section .cmdline=cmdline --change-section-vma .cmdline="$(printf 0x%x "$cmdline_offset")" \
             /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$NAME-unsigned.efi"
 
         objcopy \
-            --add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
-            --add-section .linux="/boot/vmlinuz-$KERNEL" --change-section-vma .linux=0x40000 \
-            --add-section .initrd="/boot/initramfs-$KERNEL-fallback.img" --change-section-vma .initrd=0x3000000 \
+            --add-section .osrel=/etc/os-release --change-section-vma .osrel="$(printf 0x%x "$osrel_offset")" \
+            --add-section .linux="/boot/vmlinuz-$KERNEL" --change-section-vma .linux="$(printf 0x%x "$kernel_offset")" \
+            --add-section .initrd="/boot/initramfs-$KERNEL-fallback.img" --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_default_kernel")" \
             /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$NAME-recovery-unsigned.efi"
 
         objcopy \
-            --add-section .osrel=/etc/os-release --change-section-vma .osrel=0x20000 \
-            --add-section .linux="/boot/vmlinuz-$KERNEL_LTS" --change-section-vma .linux=0x40000 \
-            --add-section .initrd="/boot/initramfs-$KERNEL_LTS-fallback.img" --change-section-vma .initrd=0x3000000 \
+            --add-section .osrel=/etc/os-release --change-section-vma .osrel="$(printf 0x%x "$osrel_offset")" \
+            --add-section .linux="/boot/vmlinuz-$KERNEL_LTS" --change-section-vma .linux="$(printf 0x%x "$kernel_offset")" \
+            --add-section .initrd="/boot/initramfs-$KERNEL_LTS-fallback.img" --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_lts_kernel")" \
             /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$NAME_LTS-recovery-unsigned.efi"
 
         for image in "$NAME" "$NAME-recovery" "$NAME_LTS-recovery" "$NAME_EFI_SHELL"; do


### PR DESCRIPTION
Fixes #17

I moved the `.cmdline` section to the end to limit the amount of offsets variations