### PR TITLE
Fix alignment of EFI binaries + inplace kernel decompression overwrite

### DIFF
--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -72,29 +72,19 @@ case "$1" in
         cat /boot/*-ucode.img "/boot/initramfs-$KERNEL.img" > ucode-initramfs.img
         cp /usr/share/edk2-shell/x64/Shell_Full.efi "$NAME_EFI_SHELL-unsigned.efi"
 
-        section_alignment="$(objdump -p /usr/lib/systemd/boot/efi/linuxx64.efi.stub | awk '{if ($1 == "SectionAlignment"){print $2}}')"
-        section_alignment=$((16#$section_alignment))
+        section_alignment="$(LC_ALL=C objdump -p /usr/lib/systemd/boot/efi/linuxx64.efi.stub | awk '/SectionAlignment/ {print strtonum("0x"$2)}')"
 
-        osrel_offset="$(objdump -h /usr/lib/systemd/boot/efi/linuxx64.efi.stub | awk 'NF==7 {size=strtonum("0x"$3); offset=strtonum("0x"$4)} END {print size + offset}')"
-        osrel_offset=$((osrel_offset + "$section_alignment" - osrel_offset % "$section_alignment"))
+        offset() {
+            echo $(("$1" + "$2" + section_alignment - ("$1" + "$2") % section_alignment))
+        }
 
-        cmdline_offset=$((osrel_offset + $(stat -Lc%s /etc/os-release)))
-        cmdline_offset=$((cmdline_offset + "$section_alignment" - cmdline_offset % "$section_alignment"))
-
-        initrd_offset_from_cmdline=$((cmdline_offset + $(stat -Lc%s cmdline)))
-        initrd_offset_from_cmdline=$((initrd_offset_from_cmdline + "$section_alignment" - initrd_offset_from_cmdline % "$section_alignment"))
-
-        initrd_offset_from_osrel=$((osrel_offset + $(stat -Lc%s /etc/os-release)))
-        initrd_offset_from_osrel=$((initrd_offset_from_osrel + "$section_alignment" - initrd_offset_from_osrel % "$section_alignment"))
-
-        default_kernel_offset=$((initrd_offset_from_cmdline + $(stat -Lc%s ucode-initramfs.img)))
-        default_kernel_offset=$((default_kernel_offset + "$section_alignment" - default_kernel_offset % "$section_alignment"))
-
-        fallback_kernel_offset=$((initrd_offset_from_osrel + $(stat -Lc%s "/boot/initramfs-$KERNEL-fallback.img")))
-        fallback_kernel_offset=$((fallback_kernel_offset + "$section_alignment" - fallback_kernel_offset % "$section_alignment"))
-
-        fallback_lts_kernel_offset=$((initrd_offset_from_osrel + $(stat -Lc%s "/boot/initramfs-$KERNEL_LTS-fallback.img")))
-        fallback_lts_kernel_offset=$((fallback_lts_kernel_offset + "$section_alignment" - fallback_lts_kernel_offset % "$section_alignment"))
+        osrel_offset="$(offset 0 "$(LC_ALL=C objdump -h /usr/lib/systemd/boot/efi/linuxx64.efi.stub | awk 'NF==7 {size=strtonum("0x"$3); offset=strtonum("0x"$4)} END {print size + offset}')")"
+        cmdline_offset="$(offset "$osrel_offset" "$(stat -Lc%s /etc/os-release)")"
+        initrd_offset_from_cmdline="$(offset "$cmdline_offset" "$(stat -Lc%s cmdline)")"
+        initrd_offset_from_osrel="$(offset "$osrel_offset" "$(stat -Lc%s /etc/os-release)")"
+        default_kernel_offset="$(offset "$initrd_offset_from_cmdline" "$(stat -Lc%s ucode-initramfs.img)")"
+        fallback_kernel_offset="$(offset "$initrd_offset_from_osrel" "$(stat -Lc%s "/boot/initramfs-$KERNEL-fallback.img")")"
+        fallback_lts_kernel_offset="$(offset "$initrd_offset_from_osrel" "$(stat -Lc%s "/boot/initramfs-$KERNEL_LTS-fallback.img")")"
 
         objcopy \
             --add-section .osrel=/etc/os-release --change-section-vma .osrel="$(printf 0x%x "$osrel_offset")" \

--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -72,13 +72,23 @@ case "$1" in
         cat /boot/*-ucode.img "/boot/initramfs-$KERNEL.img" > ucode-initramfs.img
         cp /usr/share/edk2-shell/x64/Shell_Full.efi "$NAME_EFI_SHELL-unsigned.efi"
 
+        section_alignment="$(objdump -p /usr/lib/systemd/boot/efi/linuxx64.efi.stub | awk '{if ($1 == "SectionAlignment"){print $2}}')"
+        section_alignment=$((16#$section_alignment))
+
         osrel_offset="$(objdump -h /usr/lib/systemd/boot/efi/linuxx64.efi.stub | awk 'NF==7 {size=strtonum("0x"$3); offset=strtonum("0x"$4)} END {print size + offset}')"
-        kernel_offset="$((osrel_offset + $(stat -Lc%s /etc/os-release)))"
+        osrel_offset=$((osrel_offset + "$section_alignment" - osrel_offset % "$section_alignment"))
 
-        initrd_offset_from_default_kernel="$((kernel_offset + $(stat -Lc%s "/boot/vmlinuz-$KERNEL")))"
-        initrd_offset_from_lts_kernel="$((kernel_offset + $(stat -Lc%s "/boot/vmlinuz-$KERNEL_LTS")))"
+        kernel_offset=$((osrel_offset + $(stat -Lc%s /etc/os-release)))
+        kernel_offset=$((kernel_offset + "$section_alignment" - kernel_offset % "$section_alignment"))
 
-        cmdline_offset="$((initrd_offset_from_default_kernel + $(stat -Lc%s ucode-initramfs.img)))"
+        initrd_offset_from_default_kernel=$((kernel_offset + $(stat -Lc%s "/boot/vmlinuz-$KERNEL")))
+        initrd_offset_from_default_kernel=$((initrd_offset_from_default_kernel + "$section_alignment" - initrd_offset_from_default_kernel % "$section_alignment"))
+
+        initrd_offset_from_lts_kernel=$((kernel_offset + $(stat -Lc%s "/boot/vmlinuz-$KERNEL_LTS")))
+        initrd_offset_from_lts_kernel=$((initrd_offset_from_lts_kernel + "$section_alignment" - initrd_offset_from_lts_kernel % "$section_alignment"))
+
+        cmdline_offset=$((initrd_offset_from_default_kernel + $(stat -Lc%s ucode-initramfs.img)))
+        cmdline_offset=$((cmdline_offset + "$section_alignment" - cmdline_offset % "$section_alignment"))
 
         objcopy \
             --add-section .osrel=/etc/os-release --change-section-vma .osrel="$(printf 0x%x "$osrel_offset")" \

--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -78,35 +78,41 @@ case "$1" in
         osrel_offset="$(objdump -h /usr/lib/systemd/boot/efi/linuxx64.efi.stub | awk 'NF==7 {size=strtonum("0x"$3); offset=strtonum("0x"$4)} END {print size + offset}')"
         osrel_offset=$((osrel_offset + "$section_alignment" - osrel_offset % "$section_alignment"))
 
-        kernel_offset=$((osrel_offset + $(stat -Lc%s /etc/os-release)))
-        kernel_offset=$((kernel_offset + "$section_alignment" - kernel_offset % "$section_alignment"))
-
-        initrd_offset_from_default_kernel=$((kernel_offset + $(stat -Lc%s "/boot/vmlinuz-$KERNEL")))
-        initrd_offset_from_default_kernel=$((initrd_offset_from_default_kernel + "$section_alignment" - initrd_offset_from_default_kernel % "$section_alignment"))
-
-        initrd_offset_from_lts_kernel=$((kernel_offset + $(stat -Lc%s "/boot/vmlinuz-$KERNEL_LTS")))
-        initrd_offset_from_lts_kernel=$((initrd_offset_from_lts_kernel + "$section_alignment" - initrd_offset_from_lts_kernel % "$section_alignment"))
-
-        cmdline_offset=$((initrd_offset_from_default_kernel + $(stat -Lc%s ucode-initramfs.img)))
+        cmdline_offset=$((osrel_offset + $(stat -Lc%s /etc/os-release)))
         cmdline_offset=$((cmdline_offset + "$section_alignment" - cmdline_offset % "$section_alignment"))
+
+        initrd_offset_from_cmdline=$((cmdline_offset + $(stat -Lc%s cmdline)))
+        initrd_offset_from_cmdline=$((initrd_offset_from_cmdline + "$section_alignment" - initrd_offset_from_cmdline % "$section_alignment"))
+
+        initrd_offset_from_osrel=$((osrel_offset + $(stat -Lc%s /etc/os-release)))
+        initrd_offset_from_osrel=$((initrd_offset_from_osrel + "$section_alignment" - initrd_offset_from_osrel % "$section_alignment"))
+
+        default_kernel_offset=$((initrd_offset_from_cmdline + $(stat -Lc%s ucode-initramfs.img)))
+        default_kernel_offset=$((default_kernel_offset + "$section_alignment" - default_kernel_offset % "$section_alignment"))
+
+        fallback_kernel_offset=$((initrd_offset_from_osrel + $(stat -Lc%s "/boot/initramfs-$KERNEL-fallback.img")))
+        fallback_kernel_offset=$((fallback_kernel_offset + "$section_alignment" - fallback_kernel_offset % "$section_alignment"))
+
+        fallback_lts_kernel_offset=$((initrd_offset_from_osrel + $(stat -Lc%s "/boot/initramfs-$KERNEL_LTS-fallback.img")))
+        fallback_lts_kernel_offset=$((fallback_lts_kernel_offset + "$section_alignment" - fallback_lts_kernel_offset % "$section_alignment"))
 
         objcopy \
             --add-section .osrel=/etc/os-release --change-section-vma .osrel="$(printf 0x%x "$osrel_offset")" \
-            --add-section .linux="/boot/vmlinuz-$KERNEL" --change-section-vma .linux="$(printf 0x%x "$kernel_offset")" \
-            --add-section .initrd=ucode-initramfs.img --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_default_kernel")" \
             --add-section .cmdline=cmdline --change-section-vma .cmdline="$(printf 0x%x "$cmdline_offset")" \
+            --add-section .initrd=ucode-initramfs.img --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_cmdline")" \
+            --add-section .linux="/boot/vmlinuz-$KERNEL" --change-section-vma .linux="$(printf 0x%x "$default_kernel_offset")" \
             /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$NAME-unsigned.efi"
 
         objcopy \
             --add-section .osrel=/etc/os-release --change-section-vma .osrel="$(printf 0x%x "$osrel_offset")" \
-            --add-section .linux="/boot/vmlinuz-$KERNEL" --change-section-vma .linux="$(printf 0x%x "$kernel_offset")" \
-            --add-section .initrd="/boot/initramfs-$KERNEL-fallback.img" --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_default_kernel")" \
+            --add-section .initrd="/boot/initramfs-$KERNEL-fallback.img" --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_osrel")" \
+            --add-section .linux="/boot/vmlinuz-$KERNEL" --change-section-vma .linux="$(printf 0x%x "$fallback_kernel_offset")" \
             /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$NAME-recovery-unsigned.efi"
 
         objcopy \
             --add-section .osrel=/etc/os-release --change-section-vma .osrel="$(printf 0x%x "$osrel_offset")" \
-            --add-section .linux="/boot/vmlinuz-$KERNEL_LTS" --change-section-vma .linux="$(printf 0x%x "$kernel_offset")" \
-            --add-section .initrd="/boot/initramfs-$KERNEL_LTS-fallback.img" --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_lts_kernel")" \
+            --add-section .initrd="/boot/initramfs-$KERNEL_LTS-fallback.img" --change-section-vma .initrd="$(printf 0x%x "$initrd_offset_from_osrel")" \
+            --add-section .linux="/boot/vmlinuz-$KERNEL_LTS" --change-section-vma .linux="$(printf 0x%x "$fallback_lts_kernel_offset")" \
             /usr/lib/systemd/boot/efi/linuxx64.efi.stub "$NAME_LTS-recovery-unsigned.efi"
 
         for image in "$NAME" "$NAME-recovery" "$NAME_LTS-recovery" "$NAME_EFI_SHELL"; do


### PR DESCRIPTION
Fixes #18 

Before this patch (not aligned):

```
$ sudo objdump -h /efi/EFI/arch/secure-boot-linux-hardened.efi

/efi/EFI/arch/secure-boot-linux-hardened.efi:     file format pei-x86-64

Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .text         0000bd1e  000000014df91000  000000014df91000  00000400  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  1 .rodata       000022d4  000000014df9d000  000000014df9d000  0000c200  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  2 .data         00000268  000000014dfa0000  000000014dfa0000  0000e600  2**4
                  CONTENTS, ALLOC, LOAD, DATA
  3 .sdmagic      0000002e  000000014dfa1000  000000014dfa1000  0000ea00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  4 .sbat         000000e8  000000014dfa2000  000000014dfa2000  0000ec00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  5 .reloc        00000078  000000014dfa3000  000000014dfa3000  0000ee00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  6 .osrel        00000163  000000014dfa3078  000000014dfa3078  0000f000  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  7 .linux        00af6220  000000014dfa31db  000000014dfa31db  0000f200  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  8 .initrd       01f59708  000000014ea993fb  000000014ea993fb  00b05600  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  9 .cmdline      000000ed  00000001509f2b03  00000001509f2b03  02a5ee00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
```

After this patch (aligned):

```
$ sudo objdump -h /efi/EFI/arch/secure-boot-linux-hardened.efi

/efi/EFI/arch/secure-boot-linux-hardened.efi:     file format pei-x86-64

Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .text         0000bd1e  000000014df91000  000000014df91000  00000400  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  1 .rodata       000022d4  000000014df9d000  000000014df9d000  0000c200  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  2 .data         00000268  000000014dfa0000  000000014dfa0000  0000e600  2**4
                  CONTENTS, ALLOC, LOAD, DATA
  3 .sdmagic      0000002e  000000014dfa1000  000000014dfa1000  0000ea00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  4 .sbat         000000e8  000000014dfa2000  000000014dfa2000  0000ec00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  5 .reloc        00000078  000000014dfa3000  000000014dfa3000  0000ee00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  6 .osrel        00000163  000000014dfa4000  000000014dfa4000  0000f000  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  7 .linux        00af6220  000000014dfa5000  000000014dfa5000  0000f200  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  8 .initrd       01f59708  000000014ea9c000  000000014ea9c000  00b05600  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  9 .cmdline      000000ed  00000001509f6000  00000001509f6000  02a5ee00  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
```