### PR TITLE
Pacman hook: regenerate EFI binaries if arch-secure-boot is being updated

### DIFF
--- a/pacman-hooks/95-arch-secure-boot-generate-efi.hook
+++ b/pacman-hooks/95-arch-secure-boot-generate-efi.hook
@@ -1,5 +1,4 @@
 [Trigger]
-Operation = Install
 Operation = Upgrade
 Type = Path
 Target = usr/lib/modules/*/vmlinuz
@@ -7,6 +6,7 @@ Target = usr/lib/initcpio/*
 Target = boot/*-ucode.img
 Target = usr/share/edk2-shell/x64/Shell_Full.efi
 Target = usr/lib/fwupd/efi/fwupdx64.efi
+Target = usr/bin/arch-secure-boot
 
 [Action]
 Description = Generating signed EFI boot files


### PR DESCRIPTION
Not tested.

Fixes #19 