### PR TITLE
Should improve keys insertion success rate

### DIFF
--- a/arch-secure-boot
+++ b/arch-secure-boot
@@ -139,7 +139,9 @@ case "$1" in
 
         find "$SBKEYSDIR" -mindepth 2 | read || error "Error: keys are not generated yet."
 
-        sbkeysync --verbose --pk
+        chattr -i /sys/firmware/efi/efivars/{PK,KEK,db}*
+        sbkeysync --verbose
+        efi-updatevar -f "$SBKEYSDIR/PK/PK.auth" PK
         ;;
 
     generate-keys)


### PR DESCRIPTION
Hey!

As you may know, inserting the secure boot keys into UEFI tends to fail a lot from userspace (my guess is that UEFI implementations suck). Personally I had to manually insert them from the firmware setup.

This PR is a proposal based on the [green tip from the ArchLinux wiki](https://wiki.archlinux.org/title/Unified_Extensible_Firmware_Interface/Secure_Boot#Using_sbkeysync).

I'm hoping that this way your tool will work out of the box for most vendors.